### PR TITLE
Added clear() method to GridPatternView class.

### DIFF
--- a/library/src/main/java/mobi/parchment/widget/adapterview/gridpatternview/GridPatternLayoutManager.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/gridpatternview/GridPatternLayoutManager.java
@@ -416,4 +416,9 @@ public class GridPatternLayoutManager extends LayoutManager<GridPatternGroup> {
         final GridPatternGroupDefinition gridPatternGroupDefinition = mGridPatternGroupDefinitions.get(index);
         return gridPatternGroupDefinition;
     }
+    
+    public void clearGridPatternGroupDefinition() {
+    	mGridPatternGroupDefinitions.clear();
+        mNumberOfGridItemsPerRepetition = 0;
+    }
 }

--- a/library/src/main/java/mobi/parchment/widget/adapterview/gridpatternview/GridPatternView.java
+++ b/library/src/main/java/mobi/parchment/widget/adapterview/gridpatternview/GridPatternView.java
@@ -63,5 +63,15 @@ public class GridPatternView<ADAPTER extends Adapter> extends AbstractAdapterVie
         final GridPatternGroupDefinition gridPatternGroupDefinition = new GridPatternGroupDefinition(mIsVerticalScroll, gridPatternItemDefinitions);
         mGridPatternLayoutManager.addGridPatternGroupDefinition(gridPatternGroupDefinition);
     }
-
+    
+    // ===================
+    // Added By Tom Yu
+    // ===================
+    public void add(final List<GridPatternItemDefinition> gridPatternItemDefinitions) {
+    	addGridPatternGroupDefinition(gridPatternItemDefinitions);
+    }
+    
+    public void clear() {
+    	mGridPatternLayoutManager.clearGridPatternGroupDefinition();
+    }
 }


### PR DESCRIPTION
Added clear() method to GridPatternView class. Zoom in/out  can be achieved by clearing and re-adding the GridPatternItemDefinitions along with re-ordering the backing data for the adapter.
